### PR TITLE
update sample to use tempo polling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
       - ./tempo-data:/var/tempo
     ports:
-      - "3200:3200"   # tempo
+      - "3200:80"   # tempo http
       - "9095:9095" # tempo grpc
     depends_on:
       - init

--- a/otel-collector.yaml
+++ b/otel-collector.yaml
@@ -15,14 +15,10 @@ exporters:
     endpoint: http://tempo:4318
     tls:
       insecure: true
-  otlphttp/tracetest:  # Second HTTP exporter to Tracetest agent
-    endpoint: http://tracetest-agent:4318
-    tls:
-      insecure: true
 
 service:
   pipelines:
     traces/1:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/tempo, otlphttp/tracetest]
+      exporters: [otlphttp/tempo]

--- a/tempo.yaml
+++ b/tempo.yaml
@@ -1,6 +1,6 @@
 stream_over_http_enabled: true
 server:
-  http_listen_port: 3200
+  http_listen_port: 80
   log_level: info
 
 query_frontend:

--- a/tracetest-test.yaml
+++ b/tracetest-test.yaml
@@ -1,0 +1,17 @@
+type: Test
+spec:
+  id: XyJkbaeIg
+  name: Test API
+  trigger:
+    type: http
+    httpRequest:
+      method: GET
+      url: http://app:8081
+      headers:
+      - key: Content-Type
+        value: application/json
+  specs:
+  - selector: span[tracetest.span.type="http"]
+    name: "All HTTP Spans: Status code is 200"
+    assertions:
+    - attr:http.status_code = 200

--- a/tracetest-trace-ingestion.yaml
+++ b/tracetest-trace-ingestion.yaml
@@ -1,0 +1,15 @@
+type: DataStore
+spec:
+  id: current
+  name: Grafana Tempo
+  type: tempo
+  default: true
+  tempo:
+    type: http
+    http:
+      url: http://tempo
+      tls:
+        insecure: true
+
+# RUN:
+# tracetest apply datastore -f tracetest-trace-ingestion.yaml


### PR DESCRIPTION
This PR:

- Removes otel col ingestion for Tracetest Agent
- Changes Tempo HTTP port to 80
- Adds trace ingestion YAML resource definition for Tempo